### PR TITLE
Fixes for rebuilding the VS Code extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ To format a file click `alt + shift + f` or use the format document feature in V
 ### Report an Issue
 Issues can be reported to the project on [Github](https://github.com/RasmusTidselbak/al-formatter/issues).
 
+### Rebuild the VS Code extension
+
+ git clone https://github.com/RasmusTidselbak/al-formatter.git
+ cd al-formatter/client
+ npm install -D
+ export PATH=`pwd`/node_modules/.bin:$PATH
+ vsce package
+
 ### In Development
 - RDLC Reports
 - XMLPorts

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Issues can be reported to the project on [Github](https://github.com/RasmusTidse
 
 ```
 git clone https://github.com/RasmusTidselbak/al-formatter.git
-cd al-formatter/client
+cd al-formatter/server
+npm install -D
+export PATH=`pwd`/node_modules/.bin:$PATH
+npm run compile
+cd ../client
 npm install -D
 export PATH=`pwd`/node_modules/.bin:$PATH
 vsce package

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Issues can be reported to the project on [Github](https://github.com/RasmusTidse
 
 ### Rebuild the VS Code extension
 
- git clone https://github.com/RasmusTidselbak/al-formatter.git
- cd al-formatter/client
- npm install -D
- export PATH=`pwd`/node_modules/.bin:$PATH
- vsce package
+```
+git clone https://github.com/RasmusTidselbak/al-formatter.git
+cd al-formatter/client
+npm install -D
+export PATH=`pwd`/node_modules/.bin:$PATH
+vsce package
+```
 
 ### In Development
 - RDLC Reports

--- a/client/package.json
+++ b/client/package.json
@@ -31,7 +31,8 @@
     "@types/mocha": "^2.2.43",
     "@types/node": "^6.0.88",
     "typescript": "^2.5.2",
-    "vscode": "^1.0.3"
+    "vsce": "^1.83.0",
+    "vscode": "^1.1.5"
   },
   "contributes": {
     "configuration": {
@@ -52,7 +53,6 @@
     }
   },
   "dependencies": {
-    "vscode": "^1.1.5",
     "vscode-languageclient": "^3.4.5"
   }
 }


### PR DESCRIPTION
* add section to README how to create the VS Code extension.
* fixes to package.json for the build of VS Code extension to work.